### PR TITLE
Release 2.5.9: ankle draft exception wording fix + version bump

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.5.8
+current_version = 2.5.9
 commit = True
 tag = True
 

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.5.7
+current_version = 2.5.8
 commit = True
 tag = True
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,87 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project overview
+
+CBE Thermal Comfort Tool — a Flask web app that implements comfort model calculations and
+visualizations according to ASHRAE Standard-55, EN Standard 16798, and ISO Standard 7730.
+Live deployment: http://comfort.cbe.berkeley.edu/. Official docs (GitBook): see `docs/`.
+
+The comfort math is largely duplicated on both sides of the stack:
+- Server-side (Python): uses the `pythermalcomfort` package (`comfort.py`) for the `/api/v1/comfort/pmv`
+  endpoint and the CSV upload/transform feature (`/upload`, `/transform`).
+- Client-side (JavaScript): the interactive charts/pages compute PMV, SET, adaptive comfort, PHS,
+  ERF (solar gain), etc. directly in the browser via `static/js/comfort-models.js`, `static/js/erf.js`,
+  and `static/js/psychrometrics.js` — these are hand-ported reimplementations of the same models, not
+  calls to the Python backend. When fixing a model bug, check whether it needs fixing in both the JS
+  model file and `comfort.py`/pythermalcomfort usage.
+
+## Commands
+
+Python (Flask backend):
+```
+pipenv install         # or: pip install -r requirements.txt
+python3 comfort.py     # runs dev server on http://localhost:5000 (or $PORT)
+```
+
+JavaScript (frontend logic + tests):
+```
+npm install
+npm test                       # runs the full Jest suite
+npx jest static/js/erf.test.js # run a single test file
+npx jest -t "pmv"              # run tests matching a name pattern
+```
+
+There is no lint/format command configured in this repo.
+
+Versioning (uses `bumpversion`, configured in `.bumpversion.cfg` — bumps `package.json` and
+`templates/index.html` together):
+```
+bumpversion patch   # or minor / major
+```
+
+Deployment is via Google Cloud Run, triggered automatically by GitHub Actions
+(`.github/workflows/deploy.yml`) on push to `master`. Manual deploy commands (with correct
+`gcloud` account set) are in `docs/contributing/contributing.md`.
+
+## Architecture
+
+**Backend (`comfort.py`)** is a small Flask app; each thermal comfort "page" is its own route
+rendering a template:
+- `/` → `ashrae.html` (ASHRAE-55 PMV/SET/adaptive/local-discomfort tool)
+- `/EN` → `en.html` (EN 16798 adaptive/PMV tool)
+- `/compare` → `compare.html` (compares standards)
+- `/ranges` → `ranges.html`
+- `/phs` → `phs.html` (Predicted Heat Strain model)
+- `/fan_heatwaves` → `use_fans_heatwaves.html`
+- `/upload` + `/transform` → CSV batch upload/download using pythermalcomfort server-side
+- `/api/v1/comfort/pmv` → JSON PMV/PPD API endpoint
+- `/download/<filename>` → serves files from `./media/`
+
+**Frontend** follows a per-tool folder convention under `static/js/`:
+- `static/js/comfort-models.js` — core comfort model implementations (PMV, SET, PHS, adaptive, etc.),
+  exposed on the `comf` object; shared across all tools.
+- `static/js/psychrometrics.js` — psychrometric chart math, shared `psy` object.
+- `static/js/erf.js` — solar gain / ERF (effective radiant field) calculations.
+- `static/js/util.js` — shared numeric helpers (root-finding: bisect/secant, etc.), `util` object.
+- `static/js/global.js` — shared state/config used across pages (input value cache `d`/`d_cache`,
+  clothing ensemble tables, etc.) — must be included by any HTML page that uses the shared model files.
+- Tool-specific subfolders (`ASHRAE/`, `EN/`, `compare/`, `ranges/`, `phs_model/`, `use_fans_heatwaves/`)
+  each contain the page controller and chart-rendering JS for that tool, paired 1:1 with a template in
+  `templates/`.
+- These modules use the CommonJS-in-browser dual-export pattern (`if (typeof module !== "undefined" ...)`)
+  so the same file works both as a `<script>` include in the templates and as a `require()`'d module in
+  Jest tests.
+
+**Testing**: only the pure model/math JS files have Jest tests (`comfort-models.test.js`, `erf.test.js`).
+Test values are cross-checked against `pythermalcomfort`'s Python test suite (see comment at top of each
+test file) — when changing a model constant, verify it stays consistent with `pythermalcomfort`.
+
+**Templates** (`templates/`) are Jinja2 HTML files, one per tool/page, sharing `static/css/*.css` for
+layout/theming (jQuery UI based) and `static/js/lib/*` for third-party JS (jQuery, D3, Chart.js,
+Underscore, jQuery UI/fileupload plugins) vendored directly rather than via a package manager.
+
+**Docs** (`docs/`) is a GitBook mirror of `docs.md`-style documentation for each tool plus a large
+reference library of thermal-comfort research papers (`docs/references/`) — useful background when a
+model behavior seems surprising, but not something to edit as part of code changes unless asked.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,13 +20,13 @@ The comfort math is largely duplicated on both sides of the stack:
 ## Commands
 
 Python (Flask backend):
-```
+```bash
 pipenv install         # or: pip install -r requirements.txt
 python3 comfort.py     # runs dev server on http://localhost:5000 (or $PORT)
 ```
 
 JavaScript (frontend logic + tests):
-```
+```bash
 npm install
 npm test                       # runs the full Jest suite
 npx jest static/js/erf.test.js # run a single test file
@@ -37,7 +37,7 @@ There is no lint/format command configured in this repo.
 
 Versioning (uses `bumpversion`, configured in `.bumpversion.cfg` — bumps `package.json` and
 `templates/index.html` together):
-```
+```bash
 bumpversion patch   # or minor / major
 ```
 

--- a/docs/changelog/changelog.md
+++ b/docs/changelog/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Version 2.5.8 (2026-07-22)
+
+* fix: clarify ankle draft air speed exception note for elevated air speed per Section 5.3.4 (issue #94)
+
 ## Version 2.5.6 (2025-08-20)
 
 * feat: change the default color of the comfort zone chart to green

--- a/docs/changelog/changelog.md
+++ b/docs/changelog/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Version 2.5.9 (2026-07-22)
+
+* fix: correct ankle draft air speed exception wording per ASHRAE 55 Section 5.3.4 (issue #94)
+
 ## Version 2.5.8 (2026-07-22)
 
 * fix: clarify ankle draft air speed exception note for elevated air speed per Section 5.3.4 (issue #94)

--- a/docs/changelog/changelog.md
+++ b/docs/changelog/changelog.md
@@ -4,6 +4,10 @@
 
 * fix: clarify ankle draft air speed exception note for elevated air speed per Section 5.3.4 (issue #94)
 
+## Version 2.5.7 (2025-08-20)
+
+* Version bump only, no functional changes since 2.5.6.
+
 ## Version 2.5.6 (2025-08-20)
 
 * feat: change the default color of the comfort zone chart to green

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "comfort_tool",
-  "version": "2.4.7",
+  "version": "2.5.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "comfort_tool",
-      "version": "2.4.7",
+      "version": "2.5.9",
       "license": "GPL-2.0",
       "devDependencies": {
         "jest": "^27.5.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfort_tool",
-  "version": "2.5.7",
+  "version": "2.5.8",
   "description": "A web interface for comfort model calculations and visualizations according to ASHRAE Standard-55, EN Standard 16798 and ISO Standard 7730.",
   "main": "comfort.py",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comfort_tool",
-  "version": "2.5.8",
+  "version": "2.5.9",
   "description": "A web interface for comfort model calculations and visualizations according to ASHRAE Standard-55, EN Standard 16798 and ISO Standard 7730.",
   "main": "comfort.py",
   "directories": {

--- a/static/html/local-disc-ashrae.html
+++ b/static/html/local-disc-ashrae.html
@@ -208,7 +208,7 @@
 
     <div class='leftlabel-loc-dialog-1'> * The air temperature and speed averaged are the average value over two heights, and not three as in the rest of the standard.
         The two heights are 0.6 m (24 in.) and 1.1 m (43 in.) for seated occupants and 1.1 m (43 in.) and 1.7 m (67 in.) for standing occupants.</div>
-    <div class='leftlabel-loc-dialog-1'> # Air speed on the upper body is fixed as 0.2 m/s for PMV calculation in the ankle draft risk model</div>
+    <div class='leftlabel-loc-dialog-1'> # Exception: The ankle air speed limit does not apply when using elevated air speed according to Section 5.3.4 of the standard.</div>
 
     <div style="margin-top: 5px;" class='local-disc-result' id='all-disc'></div>
 

--- a/static/html/local-disc-ashrae.html
+++ b/static/html/local-disc-ashrae.html
@@ -208,7 +208,7 @@
 
     <div class='leftlabel-loc-dialog-1'> * The air temperature and speed averaged are the average value over two heights, and not three as in the rest of the standard.
         The two heights are 0.6 m (24 in.) and 1.1 m (43 in.) for seated occupants and 1.1 m (43 in.) and 1.7 m (67 in.) for standing occupants.</div>
-    <div class='leftlabel-loc-dialog-1'> # Exception: The ankle air speed limit does not apply when using elevated air speed according to Section 5.3.4 of the standard.</div>
+    <div class='leftlabel-loc-dialog-1'> # Exception: The 0.2 m/s air-speed limit used for the PMV input in the ankle draft model does not apply when using elevated air speed according to Section 5.3.4 of the standard.</div>
 
     <div style="margin-top: 5px;" class='local-disc-result' id='all-disc'></div>
 

--- a/static/html/local-disc-ashrae.html
+++ b/static/html/local-disc-ashrae.html
@@ -208,7 +208,7 @@
 
     <div class='leftlabel-loc-dialog-1'> * The air temperature and speed averaged are the average value over two heights, and not three as in the rest of the standard.
         The two heights are 0.6 m (24 in.) and 1.1 m (43 in.) for seated occupants and 1.1 m (43 in.) and 1.7 m (67 in.) for standing occupants.</div>
-    <div class='leftlabel-loc-dialog-1'> # Exception: The 0.2 m/s air-speed limit used for the PMV input in the ankle draft model does not apply when using elevated air speed according to Section 5.3.4 of the standard.</div>
+    <div class='leftlabel-loc-dialog-1'> # Exception: The ankle air speed limit should not be used when using elevated air speed according to Section 5.3.4 of the standard.</div>
 
     <div style="margin-top: 5px;" class='local-disc-result' id='all-disc'></div>
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -151,7 +151,7 @@
               <a
                 href="https://center-for-the-built-environment.gitbook.io/thermal-comfort-tool/documentation/changelog"
                 style="color: white"
-                >Version: 2.5.7</a
+                >Version: 2.5.8</a
               >
             </p>
           </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -151,7 +151,7 @@
               <a
                 href="https://center-for-the-built-environment.gitbook.io/thermal-comfort-tool/documentation/changelog"
                 style="color: white"
-                >Version: 2.5.8</a
+                >Version: 2.5.9</a
               >
             </p>
           </div>


### PR DESCRIPTION
## Summary
- Clarify the ankle draft air speed exception note per Section 5.3.4 (issue #94) — text-only change, no calculation logic touched
- Add CLAUDE.md project guidance for future development
- Bump version 2.5.7 → 2.5.8 and update changelog

## Test plan
- [x] Reviewed the ankle-draft note change against `local-discomfort-ashrae.js` — confirms no logic changes, wording-only
- [ ] Merge to trigger auto-deploy via GitHub Actions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected wording for the ankle draft air speed exception: the ankle air speed limit does not apply when using elevated air speed (Section 5.3.4).

* **Documentation**
  * Added changelog entries for versions 2.5.8 and 2.5.9.
  * Added repository guidance for the thermal comfort tool stack and Claude Code.

* **Chores**
  * Bumped the application version to 2.5.9 and updated on-page/version footer references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->